### PR TITLE
#4 회원가입 폼 서브밋 처리

### DIFF
--- a/Spring/스프링과 JPA 기반 웹 애플리케이션 개발/studyolle/src/main/java/com/studyolle/ConsoleMailSender.java
+++ b/Spring/스프링과 JPA 기반 웹 애플리케이션 개발/studyolle/src/main/java/com/studyolle/ConsoleMailSender.java
@@ -1,0 +1,57 @@
+package com.studyolle;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.springframework.stereotype.Component;
+
+import javax.mail.internet.MimeMessage;
+import java.io.InputStream;
+
+@Profile("local")
+@Component
+@Slf4j
+public class ConsoleMailSender implements JavaMailSender {
+    @Override
+    public MimeMessage createMimeMessage() {
+        return null;
+    }
+
+    @Override
+    public MimeMessage createMimeMessage(InputStream inputStream) throws MailException {
+        return null;
+    }
+
+    @Override
+    public void send(MimeMessage mimeMessage) throws MailException {
+
+    }
+
+    @Override
+    public void send(MimeMessage... mimeMessages) throws MailException {
+
+    }
+
+    @Override
+    public void send(MimeMessagePreparator mimeMessagePreparator) throws MailException {
+
+    }
+
+    @Override
+    public void send(MimeMessagePreparator... mimeMessagePreparators) throws MailException {
+
+    }
+
+    @Override
+    public void send(SimpleMailMessage simpleMailMessage) throws MailException {
+        log.info(simpleMailMessage.getText());
+    }
+
+    @Override
+    public void send(SimpleMailMessage... simpleMailMessages) throws MailException {
+
+    }
+}

--- a/Spring/스프링과 JPA 기반 웹 애플리케이션 개발/studyolle/src/main/java/com/studyolle/account/AccountController.java
+++ b/Spring/스프링과 JPA 기반 웹 애플리케이션 개발/studyolle/src/main/java/com/studyolle/account/AccountController.java
@@ -2,6 +2,8 @@ package com.studyolle.account;
 
 import com.studyolle.domain.Account;
 import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.Errors;
@@ -17,6 +19,8 @@ import javax.validation.Valid;
 public class AccountController {
 
     private final SignUpFormValidator signUpFormValidator;
+    private final AccountRepository accountRepository;
+    private final JavaMailSender javaMailSender;
 
     @InitBinder("signUpForm")
     public void initBinder(WebDataBinder webDataBinder) {
@@ -25,16 +29,33 @@ public class AccountController {
 
     @GetMapping("/sign-up")
     public String stringUpForm(Model model){
+        model.addAttribute(new SignUpForm());
         return "account/sign-up";
     }
 
     @PostMapping("/sign-up")
-    public String signUpSubmit(@Valid SignUpForm signUpForm, Errors errors){
+    public String signUpSubmit(@Valid SignUpForm signUpForm, Errors errors) {
         if (errors.hasErrors()) {
             return "account/sign-up";
         }
-        
-        //TODO 회원가입 처리하기
+
+        Account account = Account.builder()
+                .email(signUpForm.getEmail())
+                .nickname(signUpForm.getNickname())
+                .password(signUpForm.getPassword()) // TODO encoding 해야함
+                .studyCreatedByWeb(true)
+                .studyEnrollmentResultByWeb(true)
+                .studyUpdatedByWeb(true)
+                .build();
+        Account newAccount = accountRepository.save(account);
+        newAccount.generateEmailCheckToken();
+        SimpleMailMessage mailMessage = new SimpleMailMessage();
+        mailMessage.setTo(newAccount.getEmail());
+        mailMessage.setSubject("스터디올래, 회원 가입 인증");
+        mailMessage.setText("/check-email-token?token=" + newAccount.getEmailCheckToken() +
+                "&email=" + newAccount.getEmail());
+        javaMailSender.send(mailMessage);
+
         return "redirect:/";
     }
 

--- a/Spring/스프링과 JPA 기반 웹 애플리케이션 개발/studyolle/src/main/java/com/studyolle/account/AccountRepository.java
+++ b/Spring/스프링과 JPA 기반 웹 애플리케이션 개발/studyolle/src/main/java/com/studyolle/account/AccountRepository.java
@@ -1,19 +1,14 @@
 package com.studyolle.account;
 
 import com.studyolle.domain.Account;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional(readOnly = true)
-public interface AccountRepository extends JpaRepository<Account, Long>, QuerydslPredicateExecutor<Account> {
+public interface AccountRepository extends JpaRepository<Account, Long> {
 
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
 
-    Account findByEmail(String email);
-
-    Account findByNickname(String nickname);
 }

--- a/Spring/스프링과 JPA 기반 웹 애플리케이션 개발/studyolle/src/main/java/com/studyolle/domain/Account.java
+++ b/Spring/스프링과 JPA 기반 웹 애플리케이션 개발/studyolle/src/main/java/com/studyolle/domain/Account.java
@@ -4,6 +4,7 @@ import javax.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Getter @Setter
@@ -55,5 +56,9 @@ public class Account {
 
     private boolean studyUpdateByEmail;
 
-    private boolean studyUpdateByWeb;
+    private boolean studyUpdatedByWeb;
+
+    public void generateEmailCheckToken() {
+        this.emailCheckToken = UUID.randomUUID().toString();
+    }
 }

--- a/Spring/스프링과 JPA 기반 웹 애플리케이션 개발/studyolle/src/main/resources/application.yml
+++ b/Spring/스프링과 JPA 기반 웹 애플리케이션 개발/studyolle/src/main/resources/application.yml
@@ -12,4 +12,5 @@ spring:
     cache: false
   jpa:
     open-in-view: false
-
+  profiles:
+    active: local


### PR DESCRIPTION
회원가입 버튼을 눌렀을 때 UUID를 이용해서 이메일 토큰을 발급하여 이메일이 전송되도록 설정.
실제로 이메일이 전송되는 것이 아니라 로컬에서 확인할 수 있도록 `@profile`로 범위를 제한함.
회원 비밀번호가 그대로 저장이 되어 후에 encoding이 필요하고,
다음 단계에서 리팩토링을 진행할 예정